### PR TITLE
build(deps): bump Rails to 7

### DIFF
--- a/lib/para/acl/version.rb
+++ b/lib/para/acl/version.rb
@@ -2,6 +2,6 @@
 
 module Para
   module Acl
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/para-acl.gemspec
+++ b/para-acl.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 # Add components folder to load path, allowing para to eager load it
@@ -8,7 +7,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 # This can be made standard in some way in para when we'll implement some
 # kind of plugin system
 #
-components = File.expand_path('../app/components', __FILE__)
+components = File.expand_path('app/components', __dir__)
 $LOAD_PATH.unshift(components) unless $LOAD_PATH.include?(components)
 
 require 'para/acl/version'
@@ -18,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.version       = Para::Acl::VERSION
   spec.authors       = ['Valentin Ballestrino']
   spec.email         = ['vala@glyph.fr']
-  spec.summary       = %q{Para plugin to allow admins access management}
-  spec.description   = %q{Para plugin to allow admins access management}
+  spec.summary       = 'Para plugin to allow admins access management'
+  spec.description   = 'Para plugin to allow admins access management'
   spec.homepage      = 'https://github.com/para-cms/para-acl'
   spec.license       = 'MIT'
 
@@ -29,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'para', '>= 1.0.0', '< 2'
-  spec.add_dependency 'rails', '>= 4.0', '<= 6.1'
+  spec.add_dependency 'rails', '>= 4.0', '< 7.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
# build(deps): bump Rails to 7

![ruby logo](https://img.shields.io/badge/Ruby-informational?style=flat&logo=ruby&logoColor=white&color=CC0000)

## 🗃 Carte(s) Trello

- [Rails 6.1 ➡️ 7.0](https://trello.com/c/fkuOrI39)

## ⚙️ Back

- Bump gemspec dependency to Rails 7

## 📺 Comment tester

- In your main project Gemfile, use:

```
gem 'sidekiq-job_monitor', '0.2.0', git: 'https://github.com/Kinoba/sidekiq-job_monitor.git', branch: 'build/bump-rails-dependency-to-7'
```
